### PR TITLE
Fix config exclude pattern parsing. Added tests for validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,10 +71,10 @@ type Config struct {
 	// Logs will only be written to the configured log file (if any).
 	DisableOutputLog bool `mapstructure:"disable-output-log"`
 	// Code indexing configuration
-	CodeIndexingWorkers        int    `mapstructure:"code-indexing-workers"`
-	CodeIndexingMaxSymbolSize  int    `mapstructure:"code-indexing-max-symbol-size"`
+	CodeIndexingWorkers         int    `mapstructure:"code-indexing-workers"`
+	CodeIndexingMaxSymbolSize   int    `mapstructure:"code-indexing-max-symbol-size"`
 	CodeIndexingExcludePatterns string `mapstructure:"code-indexing-exclude-patterns"`
-	CodeIndexingMaxFileSize    int64  `mapstructure:"code-indexing-max-file-size"`
+	CodeIndexingMaxFileSize     int64  `mapstructure:"code-indexing-max-file-size"`
 	// Code monitoring configuration
 	// When true, disables automatic code file watching for projects
 	DisableCodeWatch bool `mapstructure:"disable-code-watch"`
@@ -220,6 +220,10 @@ func Load() (*Config, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
+	// Normalize exclusion patterns so both YAML lists and comma-separated strings
+	// are accepted without breaking existing behavior.
+	normalizeCodeIndexingExcludePatterns(v)
+
 	// Unmarshal the configuration
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
@@ -232,6 +236,44 @@ func Load() (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func normalizeCodeIndexingExcludePatterns(v *viper.Viper) {
+	raw := v.Get("code-indexing-exclude-patterns")
+	if raw == nil {
+		return
+	}
+
+	toPatternList := func(values []any) []string {
+		patterns := make([]string, 0, len(values))
+		for _, value := range values {
+			pattern := strings.TrimSpace(fmt.Sprint(value))
+			if pattern != "" {
+				patterns = append(patterns, pattern)
+			}
+		}
+		return patterns
+	}
+
+	switch values := raw.(type) {
+	case []string:
+		if len(values) == 0 {
+			return
+		}
+		items := make([]any, 0, len(values))
+		for _, value := range values {
+			items = append(items, value)
+		}
+		patterns := toPatternList(items)
+		if len(patterns) > 0 {
+			v.Set("code-indexing-exclude-patterns", strings.Join(patterns, ","))
+		}
+	case []any:
+		patterns := toPatternList(values)
+		if len(patterns) > 0 {
+			v.Set("code-indexing-exclude-patterns", strings.Join(patterns, ","))
+		}
+	}
 }
 
 // Validate checks if the configuration is valid.

--- a/internal/indexer/file_scanner.go
+++ b/internal/indexer/file_scanner.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -324,8 +325,23 @@ func (s *FileScanner) ShouldExclude(absPath, relPath string, isDir bool) bool {
 func (s *FileScanner) shouldExclude(absPath, relPath string, isDir bool) bool {
 	// Get the base name
 	name := filepath.Base(absPath)
+	relPathUnix := filepath.ToSlash(filepath.Clean(relPath))
 
 	for _, pattern := range s.ExcludePatterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+
+		patternUnix := filepath.ToSlash(pattern)
+
+		// Path-aware glob match for patterns like "folder/*.php"
+		if strings.Contains(patternUnix, "/") {
+			if matched, err := path.Match(patternUnix, relPathUnix); err == nil && matched {
+				return true
+			}
+		}
+
 		// Check if pattern starts with * (wildcard)
 		if strings.HasPrefix(pattern, "*") {
 			suffix := strings.TrimPrefix(pattern, "*")

--- a/tests/file_scanner_exclude_patterns_test.go
+++ b/tests/file_scanner_exclude_patterns_test.go
@@ -174,6 +174,24 @@ func TestFileScanner_ExclusionPatterns_CommaSeparatedConfiguredValues(t *testing
 	}
 }
 
+func TestFileScanner_ExclusionPatterns_PathPatternFolderPHP(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(tempDir, "folder", "file.php"), "<?php echo 'skip';")
+	mustWriteFile(t, filepath.Join(tempDir, "folder", "file.js"), "function keep() {}")
+
+	scanner := indexer.NewFileScanner()
+	scanner.MergeExcludePatterns([]string{"folder/*.php"})
+
+	scanResult, err := scanner.Scan(tempDir)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	assertNotIndexed(t, scanResult.Files, filepath.Join("folder", "file.php"), "expected folder/*.php pattern to exclude PHP file")
+	assertIndexed(t, scanResult.Files, filepath.Join("folder", "file.js"), "expected non-matching file in same folder to remain indexed")
+}
+
 func containsString(items []string, value string) bool {
 	for _, item := range items {
 		if item == value {

--- a/tests/file_scanner_exclude_patterns_test.go
+++ b/tests/file_scanner_exclude_patterns_test.go
@@ -1,0 +1,218 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/madeindigio/remembrances-mcp/internal/config"
+	"github.com/madeindigio/remembrances-mcp/internal/indexer"
+)
+
+func TestFileScanner_ExclusionPatterns_DefaultsAndConfiguredValues(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(tempDir, "main.go"), "package main\nfunc main() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "auto.generated.go"), "package main\nfunc generated() {}\n")
+
+	// Directories excluded by built-in defaults.
+	mustWriteFile(t, filepath.Join(tempDir, "vendor", "ignored.go"), "package vendorpkg\nfunc IgnoredVendor() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "node_modules", "ignored.js"), "function ignoredNodeModules() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, ".cache", "ignored.py"), "def ignored_cache():\n    pass\n")
+
+	// Directories excluded only when user-configured patterns are merged.
+	mustWriteFile(t, filepath.Join(tempDir, "var", "ignored.go"), "package varpkg\nfunc Ignored() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "custom_out", "ignored.go"), "package custompkg\nfunc IgnoredCustom() {}\n")
+
+	defaultScanner := indexer.NewFileScanner()
+	defaultScanResult, err := defaultScanner.Scan(tempDir)
+	if err != nil {
+		t.Fatalf("default scan failed: %v", err)
+	}
+
+	assertNotIndexed(t, defaultScanResult.Files, filepath.Join("vendor", "ignored.go"), "expected built-in default pattern to exclude vendor")
+	assertNotIndexed(t, defaultScanResult.Files, filepath.Join("node_modules", "ignored.js"), "expected built-in default pattern to exclude node_modules")
+	assertNotIndexed(t, defaultScanResult.Files, filepath.Join(".cache", "ignored.py"), "expected hidden/cache directories to be excluded by default")
+	assertIndexed(t, defaultScanResult.Files, filepath.Join("var", "ignored.go"), "expected var to be indexed before user-configured exclude patterns are merged")
+	assertIndexed(t, defaultScanResult.Files, filepath.Join("custom_out", "ignored.go"), "expected custom_out to be indexed before user-configured exclude patterns are merged")
+
+	cfgYAML := "gguf-model-path: \"/tmp/fake-model.gguf\"\n" +
+		"db-path: \"/tmp/remembrances-test.db\"\n" +
+		"code-indexing-exclude-patterns:\n" +
+		"  - var\n" +
+		"  - custom_out\n" +
+		"  - \"*.generated.go\"\n"
+
+	cfgPath := filepath.Join(tempDir, "config.yaml")
+	mustWriteFile(t, cfgPath, cfgYAML)
+
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+	os.Args = []string{"remembrances-mcp", "--config", cfgPath}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	patterns := cfg.GetCodeIndexingExcludePatterns()
+	if len(patterns) != 3 {
+		t.Fatalf("expected 3 configured exclude patterns, got %d (%v)", len(patterns), patterns)
+	}
+
+	scanner := indexer.NewFileScanner()
+	if len(patterns) > 0 {
+		scanner.MergeExcludePatterns(patterns)
+	}
+
+	scanResult, err := scanner.Scan(tempDir)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	// Built-in defaults still apply after merging user patterns.
+	assertNotIndexed(t, scanResult.Files, filepath.Join("vendor", "ignored.go"), "expected built-in default pattern to remain active after merging user patterns")
+	assertNotIndexed(t, scanResult.Files, filepath.Join("node_modules", "ignored.js"), "expected built-in default pattern to remain active after merging user patterns")
+
+	// User-configured exclusions (including multiple values) are enforced.
+	assertNotIndexed(t, scanResult.Files, filepath.Join("var", "ignored.go"), "expected configured pattern var to exclude directory")
+	assertNotIndexed(t, scanResult.Files, filepath.Join("custom_out", "ignored.go"), "expected configured pattern custom_out to exclude directory")
+	assertNotIndexed(t, scanResult.Files, "auto.generated.go", "expected configured wildcard pattern *.generated.go to exclude generated file")
+
+	// Non-excluded file is still indexed.
+	assertIndexed(t, scanResult.Files, "main.go", "expected main.go to remain indexed")
+}
+
+func TestFileScanner_ExclusionPatterns_CommaSeparatedConfiguredValues(t *testing.T) {
+	testCases := []struct {
+		name     string
+		raw      string
+		expected []string
+	}{
+		{
+			name:     "comma_with_spaces",
+			raw:      "one, two, three",
+			expected: []string{"one", "two", "three"},
+		},
+		{
+			name:     "comma_without_spaces",
+			raw:      "one,two,three",
+			expected: []string{"one", "two", "three"},
+		},
+		{
+			name:     "mixed_spacing",
+			raw:      "one , two, three ,four",
+			expected: []string{"one", "two", "three", "four"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			mustWriteFile(t, filepath.Join(tempDir, "main.go"), "package main\nfunc main() {}\n")
+
+			// Directories excluded by built-in defaults.
+			mustWriteFile(t, filepath.Join(tempDir, "vendor", "ignored.go"), "package vendorpkg\nfunc IgnoredVendor() {}\n")
+			mustWriteFile(t, filepath.Join(tempDir, "node_modules", "ignored.js"), "function ignoredNodeModules() {}\n")
+
+			// Directories expected to be excluded by configured comma-separated values.
+			mustWriteFile(t, filepath.Join(tempDir, "one", "ignored.go"), "package onepkg\nfunc IgnoredOne() {}\n")
+			mustWriteFile(t, filepath.Join(tempDir, "two", "ignored.go"), "package twopkg\nfunc IgnoredTwo() {}\n")
+			mustWriteFile(t, filepath.Join(tempDir, "three", "ignored.go"), "package threepkg\nfunc IgnoredThree() {}\n")
+			mustWriteFile(t, filepath.Join(tempDir, "four", "ignored.go"), "package fourpkg\nfunc IgnoredFour() {}\n")
+
+			defaultScanner := indexer.NewFileScanner()
+			defaultScanResult, err := defaultScanner.Scan(tempDir)
+			if err != nil {
+				t.Fatalf("default scan failed: %v", err)
+			}
+
+			assertNotIndexed(t, defaultScanResult.Files, filepath.Join("vendor", "ignored.go"), "expected built-in default pattern to exclude vendor")
+			assertNotIndexed(t, defaultScanResult.Files, filepath.Join("node_modules", "ignored.js"), "expected built-in default pattern to exclude node_modules")
+			assertIndexed(t, defaultScanResult.Files, filepath.Join("one", "ignored.go"), "expected one to be indexed before user-configured exclude patterns are merged")
+			assertIndexed(t, defaultScanResult.Files, filepath.Join("two", "ignored.go"), "expected two to be indexed before user-configured exclude patterns are merged")
+			assertIndexed(t, defaultScanResult.Files, filepath.Join("three", "ignored.go"), "expected three to be indexed before user-configured exclude patterns are merged")
+			assertIndexed(t, defaultScanResult.Files, filepath.Join("four", "ignored.go"), "expected four to be indexed before user-configured exclude patterns are merged")
+
+			cfg := &config.Config{CodeIndexingExcludePatterns: tc.raw}
+			patterns := cfg.GetCodeIndexingExcludePatterns()
+			if len(patterns) != len(tc.expected) {
+				t.Fatalf("expected %d configured exclude patterns, got %d (%v)", len(tc.expected), len(patterns), patterns)
+			}
+			for i, expected := range tc.expected {
+				if patterns[i] != expected {
+					t.Fatalf("unexpected parsed pattern at index %d: got %q want %q (raw: %q)", i, patterns[i], expected, tc.raw)
+				}
+			}
+
+			scanner := indexer.NewFileScanner()
+			scanner.MergeExcludePatterns(patterns)
+
+			scanResult, err := scanner.Scan(tempDir)
+			if err != nil {
+				t.Fatalf("scan failed: %v", err)
+			}
+
+			// Built-in defaults still apply after merging user patterns.
+			assertNotIndexed(t, scanResult.Files, filepath.Join("vendor", "ignored.go"), "expected built-in default pattern to remain active after merging user patterns")
+			assertNotIndexed(t, scanResult.Files, filepath.Join("node_modules", "ignored.js"), "expected built-in default pattern to remain active after merging user patterns")
+
+			// User-configured comma-separated exclusions are enforced.
+			for _, dir := range tc.expected {
+				assertNotIndexed(t, scanResult.Files, filepath.Join(dir, "ignored.go"), "expected configured pattern to exclude directory")
+			}
+
+			if !containsString(tc.expected, "four") {
+				assertIndexed(t, scanResult.Files, filepath.Join("four", "ignored.go"), "expected four to remain indexed when not part of configured patterns")
+			}
+
+			assertIndexed(t, scanResult.Files, "main.go", "expected main.go to remain indexed")
+		})
+	}
+}
+
+func containsString(items []string, value string) bool {
+	for _, item := range items {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRelPath(files []indexer.ScannedFile, relPath string) bool {
+	relPath = filepath.Clean(relPath)
+	for _, file := range files {
+		if filepath.Clean(file.RelPath) == relPath {
+			return true
+		}
+	}
+	return false
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create parent directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+}
+
+func assertIndexed(t *testing.T, files []indexer.ScannedFile, relPath, msg string) {
+	t.Helper()
+	if !containsRelPath(files, relPath) {
+		t.Fatalf("%s: %q not found in indexed files", msg, relPath)
+	}
+}
+
+func assertNotIndexed(t *testing.T, files []indexer.ScannedFile, relPath, msg string) {
+	t.Helper()
+	if containsRelPath(files, relPath) {
+		t.Fatalf("%s: %q was unexpectedly indexed", msg, relPath)
+	}
+}

--- a/tests/indexer_exclusion_handoff_test.go
+++ b/tests/indexer_exclusion_handoff_test.go
@@ -1,0 +1,157 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/madeindigio/remembrances-mcp/internal/indexer"
+	"github.com/madeindigio/remembrances-mcp/internal/storage"
+	"github.com/madeindigio/remembrances-mcp/pkg/treesitter"
+)
+
+func TestIndexer_IndexProject_DoesNotProcessExcludedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(tempDir, "main.go"), "package main\nfunc main() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "internal", "service", "service.go"), "package service\nfunc Run() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "pkg", "util", "helpers.go"), "package util\nfunc Help() {}\n")
+
+	// Excluded by built-in defaults.
+	mustWriteFile(t, filepath.Join(tempDir, "vendor", "dep", "ignored.go"), "package dep\nfunc VendorSkip() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "node_modules", "lib", "ignored.js"), "function nodeSkip() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, ".cache", "ignored.py"), "def cache_skip():\n    pass\n")
+
+	// Excluded by user-configured patterns.
+	mustWriteFile(t, filepath.Join(tempDir, "var", "ignored.go"), "package ignored\nfunc SkipMe() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "custom_out", "ignored.go"), "package ignored\nfunc SkipCustomOut() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "auto.generated.go"), "package main\nfunc Generated() {}\n")
+	mustWriteFile(t, filepath.Join(tempDir, "folder", "file.php"), "<?php echo 'skip';")
+	mustWriteFile(t, filepath.Join(tempDir, "folder", "file.js"), "function keep() {}")
+
+	scanner := indexer.NewFileScanner()
+	scanner.MergeExcludePatterns([]string{"var", "custom_out", "*.generated.go", "folder/*.php"})
+
+	cfg := indexer.DefaultIndexerConfig()
+	cfg.Scanner = scanner
+	cfg.Concurrency = 1
+
+	spyStorage := &indexerSpyStorage{SurrealDBStorage: &storage.SurrealDBStorage{}}
+	idx := indexer.NewIndexer(spyStorage, &stubEmbedder{}, cfg)
+
+	projectID, err := idx.IndexProject(context.Background(), tempDir, "handoff-test")
+	if err != nil {
+		t.Fatalf("indexing failed: %v", err)
+	}
+	if projectID == "" {
+		t.Fatalf("expected non-empty project ID")
+	}
+
+	includedFiles := []string{
+		"main.go",
+		filepath.Join("internal", "service", "service.go"),
+		filepath.Join("pkg", "util", "helpers.go"),
+		filepath.Join("folder", "file.js"),
+	}
+	excludedFiles := []string{
+		filepath.Join("vendor", "dep", "ignored.go"),
+		filepath.Join("node_modules", "lib", "ignored.js"),
+		filepath.Join(".cache", "ignored.py"),
+		filepath.Join("var", "ignored.go"),
+		filepath.Join("custom_out", "ignored.go"),
+		filepath.Join("folder", "file.php"),
+		"auto.generated.go",
+	}
+
+	for _, relPath := range includedFiles {
+		assertContainsPath(t, spyStorage.getCodeFileCalls, relPath, "expected included file to be checked for existing record")
+		assertContainsPath(t, spyStorage.savedCodeFiles, relPath, "expected included file to be saved")
+	}
+
+	for _, relPath := range excludedFiles {
+		assertNotContainsPath(t, spyStorage.getCodeFileCalls, relPath, "excluded file should not be checked in storage")
+		assertNotContainsPath(t, spyStorage.savedCodeFiles, relPath, "excluded file should never be saved downstream")
+	}
+
+	if got, want := len(spyStorage.savedCodeFiles), len(includedFiles); got != want {
+		t.Fatalf("expected exactly %d saved included files, got %d (%v)", want, got, spyStorage.savedCodeFiles)
+	}
+}
+
+type indexerSpyStorage struct {
+	*storage.SurrealDBStorage
+
+	getCodeFileCalls []string
+	savedCodeFiles   []string
+}
+
+func (s *indexerSpyStorage) CreateCodeProject(ctx context.Context, project *treesitter.CodeProject) error {
+	return nil
+}
+
+func (s *indexerSpyStorage) UpdateProjectStatus(ctx context.Context, projectID string, status treesitter.IndexingStatus) error {
+	return nil
+}
+
+func (s *indexerSpyStorage) GetCodeFile(ctx context.Context, projectID, filePath string) (*storage.CodeFile, error) {
+	s.getCodeFileCalls = append(s.getCodeFileCalls, filepath.Clean(filePath))
+	return nil, nil
+}
+
+func (s *indexerSpyStorage) SaveCodeSymbols(ctx context.Context, symbols []*treesitter.CodeSymbol) error {
+	return nil
+}
+
+func (s *indexerSpyStorage) SaveCodeFile(ctx context.Context, file *treesitter.CodeFile) error {
+	s.savedCodeFiles = append(s.savedCodeFiles, filepath.Clean(file.FilePath))
+	return nil
+}
+
+func (s *indexerSpyStorage) DeleteChunksByFile(ctx context.Context, projectID, filePath string) error {
+	return nil
+}
+
+func (s *indexerSpyStorage) SaveCodeChunks(ctx context.Context, chunks []*storage.CodeChunk) error {
+	return nil
+}
+
+type stubEmbedder struct{}
+
+func (e *stubEmbedder) EmbedDocuments(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{0.1, 0.2, 0.3}
+	}
+	return out, nil
+}
+
+func (e *stubEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+
+func (e *stubEmbedder) Dimension() int {
+	return 3
+}
+
+func assertContainsPath(t *testing.T, paths []string, expected, msg string) {
+	t.Helper()
+	expected = filepath.Clean(expected)
+	for _, p := range paths {
+		if filepath.Clean(p) == expected {
+			return
+		}
+	}
+	t.Fatalf("%s: expected %q in %v", msg, expected, paths)
+}
+
+func assertNotContainsPath(t *testing.T, paths []string, forbidden, msg string) {
+	t.Helper()
+	forbidden = filepath.Clean(forbidden)
+	for _, p := range paths {
+		if filepath.Clean(p) == forbidden {
+			t.Fatalf("%s: found forbidden path %q in %v", msg, forbidden, paths)
+		}
+	}
+}
+
+var _ storage.FullStorage = (*indexerSpyStorage)(nil)


### PR DESCRIPTION
This PR fixes and hardens code-indexing exclusion handling and adds comprehensive regression coverage for exclusion behavior.

What changed
- Added config normalization to accept both:
   - YAML list values
   - Comma-separated string values
- Added path-aware glob match for patterns like "folder/*.php"

What stayed
- Preserved backward compatibility with existing comma-separated usage.
- Kept scanner exclusion semantics unchanged (minimal/non-breaking fix).

Tests
- Expanded regression tests to cover:
   - Built-in default exclusions
   - User-provided exclusions
   - Multiple pattern values
   - Wildcard pattern exclusion
   - Irregular comma-separated formatting variants