### PR TITLE
TOON serialization bugfix

### DIFF
--- a/pkg/mcp_tools/code_search_tools_handlers.go
+++ b/pkg/mcp_tools/code_search_tools_handlers.go
@@ -61,7 +61,7 @@ func (cstm *CodeSearchToolManager) codeGetSymbolsOverviewHandler(ctx context.Con
 		if sym.ParentID == nil && len(topLevelSymbols) < input.MaxResults {
 			topLevelSymbols = append(topLevelSymbols, map[string]interface{}{
 				"name":       sym.Name,
-				"type":       sym.SymbolType,
+				"type":       string(sym.SymbolType),
 				"name_path":  sym.NamePath,
 				"start_line": sym.StartLine,
 				"end_line":   sym.EndLine,
@@ -72,7 +72,7 @@ func (cstm *CodeSearchToolManager) codeGetSymbolsOverviewHandler(ctx context.Con
 
 	result := map[string]interface{}{
 		"file_path": input.RelativePath,
-		"language":  file.Language,
+		"language":  string(file.Language),
 		"symbols":   topLevelSymbols,
 		"count":     len(topLevelSymbols),
 	}
@@ -301,10 +301,10 @@ func (cstm *CodeSearchToolManager) codeSearchSymbolsSemanticHandler(ctx context.
 	for _, r := range results {
 		sym := map[string]interface{}{
 			"name":       r.Symbol.Name,
-			"type":       r.Symbol.SymbolType,
+			"type":       string(r.Symbol.SymbolType),
 			"name_path":  r.Symbol.NamePath,
 			"file_path":  r.Symbol.FilePath,
-			"language":   r.Symbol.Language,
+			"language":   string(r.Symbol.Language),
 			"start_line": r.Symbol.StartLine,
 			"end_line":   r.Symbol.EndLine,
 			"signature":  r.Symbol.Signature,


### PR DESCRIPTION
## Bug

Missing type cast causes serialization failure in `code_get_symbols_overview` and `code_search_symbols_semantic` tools. When `treesitter.Language` and `treesitter.SymbolType` custom types are passed directly into the response map, the TOON serializer fails at runtime because it only handles primitive types. Both tools were completely unusable as a result.

## Fix

Cast `treesitter.Language` and `treesitter.SymbolType` to `string` before inserting them into the response map. Both types are defined as `type X string` so the cast is safe and lossless.

## Files changed

- `pkg/mcp_tools/code_search_tools_handlers.go`
  - `codeGetSymbolsOverviewHandler`: `sym.SymbolType` → `string(sym.SymbolType)`, `file.Language` → `string(file.Language)`
  - `codeSearchSymbolsSemanticHandler`: `r.Symbol.SymbolType` → `string(r.Symbol.SymbolType)`, `r.Symbol.Language` → `string(r.Symbol.Language)`

## Testing

Verified against a real Swift/Objective-C project (~4,300 files, ~45,000 symbols). 
Both tools return correct results after the fix.